### PR TITLE
Pretend to accept container ACL modifications

### DIFF
--- a/lib/routes/ContainerRoute.js
+++ b/lib/routes/ContainerRoute.js
@@ -39,6 +39,10 @@ module.exports = (app) => {
             if (req.query.restype === 'container' && req.query.comp === 'metadata') {
                 setContainerMetadataHandler.process(req, res, req.params.container);
             }
+            else if (req.query.restype === 'container' && req.query.comp === 'acl') {
+                // Not fully supported, but that's no reason to fail!
+                res.send();
+            }
             else if (req.query.restype === 'container') {
                 createContainerHandler.process(req, res, req.params.container);
             }


### PR DESCRIPTION
An application of ours I was trying to use with `azurite` made a call to the container ACL API on startup.

Actually implementing the ACL logic would be quite a bit of work, but for the purposes of being a fake azure it seemed like simply accepting modification requests and doing nothing would be useful in the short term.

This is the change I've made to get things working for us - if you think it's reasonable then feel free to merge.