### PR TITLE
Added docker file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ azurite-testdrive
 
 # Arafato
 NOTES
+
+#IntelliJ
+.idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:alpine
+
+WORKDIR /opt/azurite
+
+COPY package.json /opt/azurite
+RUN npm install
+
+COPY bin /opt/azurite/bin
+COPY lib /opt/azurite/lib
+
+VOLUME /opt/azurite/folder
+
+EXPOSE 10000
+
+CMD ["node", "bin/azurite", "-l", "/opt/azurite/folder"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ Then simply start it with the following command:
 
 This tells Azurite to store all data in a particular directory. If the `-l` option is ommitted it will use the current working directory.
 
+
+## Docker image
+### Build the Docker image
+To build the Docker image, execute the following:
+```bash
+docker build -t arafato/azurite .
+```
+
+### Run the Docker image
+To run the Docker image, execute the following command:
+```bash
+docker run -d -t -p 10000:10000 -v /path/to/folder:/opt/azurite/folder arafato/azurite
+```
+
 # Contributions
 ## What do I need to know to help?
 If you are interested in making a code contribution and would like to learn more about the technologies that we use, check out the list below.


### PR DESCRIPTION
Added docker file so it can be pulled in dynamically by machines that do not have node/npm installed

Our use case is that we have a Java application that interacts with Azure, but we want to be able to test it on our Jenkins instance and our Linux dev machines. We could install azurite via npm on our Jenkins instance, but I find it much nicer to not have to bring in extra dependencies on our dev machines and Jenkins, which never require node/npm.