### PR TITLE
Return queue length with metadata

### DIFF
--- a/lib/actions/queue/GetQueueMetadata.js
+++ b/lib/actions/queue/GetQueueMetadata.js
@@ -12,7 +12,8 @@ class GetQueueMetadata {
             metaProps = queue.metaProps,
             queueLength = queue.getLength(),
             response = new AzuriteQueueResponse();
-        response.addMetaProps(metaProps, queueLength);
+        response.addMetaProps(metaProps);
+        response.addHttpProperty(`x-ms-approximate-messages-count`, queueLength);
         res.set(response.httpProps);
         res.status(200).send();
     }

--- a/lib/actions/queue/GetQueueMetadata.js
+++ b/lib/actions/queue/GetQueueMetadata.js
@@ -10,8 +10,9 @@ class GetQueueMetadata {
     process(request, res) {
         const queue = QueueManager.getQueueAndMessage({ queueName: request.queueName }).queue,
             metaProps = queue.metaProps,
+            queueLength = queue.getLength(),
             response = new AzuriteQueueResponse();
-        response.addMetaProps(metaProps);
+        response.addMetaProps(metaProps, queueLength);
         res.set(response.httpProps);
         res.status(200).send();
     }

--- a/lib/model/queue/AzuriteQueueResponse.js
+++ b/lib/model/queue/AzuriteQueueResponse.js
@@ -17,10 +17,11 @@ class AzuriteQueueResponse {
         }
     }
 
-    addMetaProps(metaProps) {
+    addMetaProps(metaProps, queueLength) {
         Object.keys(metaProps).forEach((key) => {
             this.addHttpProperty(`x-ms-meta-${key}`, metaProps[key]);
         });
+        this.addHttpProperty(`x-ms-approximate-messages-count`, queueLength);
     }
 }
 

--- a/lib/model/queue/AzuriteQueueResponse.js
+++ b/lib/model/queue/AzuriteQueueResponse.js
@@ -21,7 +21,6 @@ class AzuriteQueueResponse {
         Object.keys(metaProps).forEach((key) => {
             this.addHttpProperty(`x-ms-meta-${key}`, metaProps[key]);
         });
-        this.addHttpProperty(`x-ms-approximate-messages-count`, queueLength);
     }
 }
 

--- a/lib/model/queue/AzuriteQueueResponse.js
+++ b/lib/model/queue/AzuriteQueueResponse.js
@@ -17,7 +17,7 @@ class AzuriteQueueResponse {
         }
     }
 
-    addMetaProps(metaProps, queueLength) {
+    addMetaProps(metaProps) {
         Object.keys(metaProps).forEach((key) => {
             this.addHttpProperty(`x-ms-meta-${key}`, metaProps[key]);
         });

--- a/lib/model/queue/Queue.js
+++ b/lib/model/queue/Queue.js
@@ -122,6 +122,10 @@ class Queue {
             index: index
         };
     }
+
+    getLength() {
+        return this.messages.length;
+    }
 }
 
 module.exports = Queue;


### PR DESCRIPTION
Added feature from the queue API: returning queue length with the metadata.