### PR TITLE
Pageblob bug fixes

### DIFF
--- a/lib/core/blob/StorageManager.js
+++ b/lib/core/blob/StorageManager.js
@@ -351,7 +351,7 @@ class StorageManager {
             .data();
 
         const pageWriteMode = request.httpProps[N.PAGE_WRITE];
-        const isClear = pageWriteMode === 'clear';
+        const isClear = pageWriteMode.toLowerCase() === 'clear';
 
         this._updatePageRanges(coll, pageRanges, startByte, endByte, request.id, isClear);
 
@@ -397,18 +397,31 @@ class StorageManager {
             // If range exists it is guaranteed to be well-formed due to PageAlignment validation
             const parts = request.httpProps[N.RANGE].split('=')[1].split('-'),
                 startByte = parseInt(parts[0]),
-                endByte = parseInt(parts[1]);
+                endByte = parseInt(parts[1]),
+                startAlignment = startByte / 512,
+                endAlignment = (endByte + 1) / 512;
+
             pageRanges = coll.chain()
                 .find({
                     '$and': [
-                        { 'end': { '$gte': startByte } },
-                        { 'start': { '$lte': endByte } },
+                        { 'end': { '$gt': startAlignment } },
+                        { 'start': { '$lt': endAlignment } },
                         { 'parentId': { '$eq': request.id } }]
                 })
                 .sort((a, b) => {
                     return a.start - b.start;
                 })
                 .data();
+
+            // Trim the page ranges being returned to fit inside the request range.
+            const firstPage = pageRanges[0];
+            const lastPage = pageRanges[pageRanges.length - 1];
+            if (firstPage && firstPage.start < startAlignment) {
+                firstPage.start = startAlignment;
+            }
+            if (lastPage && lastPage.end > endAlignment) {
+                lastPage.end = endAlignment;
+            }
         } else {
             pageRanges = coll.chain()
                 .find({ 'parentId': { '$eq': request.id } })

--- a/lib/core/blob/StorageManager.js
+++ b/lib/core/blob/StorageManager.js
@@ -360,10 +360,10 @@ class StorageManager {
             });
 
         let pageContent;
-        if (pageWriteMode === 'Update') {
+        if (pageWriteMode === 'update') {
             pageContent = request.body;
         }
-        if (pageWriteMode === 'Clear') {
+        if (pageWriteMode === 'clear') {
             pageContent = new Array(endbyte - startbyte + 1).fill('\0').join('');
         }
         return new BbPromise((resolve, reject) => {

--- a/lib/core/blob/StorageManager.js
+++ b/lib/core/blob/StorageManager.js
@@ -350,22 +350,28 @@ class StorageManager {
             })
             .data();
 
-        this._updatePageRanges(coll, pageRanges, startByte, endByte, request.id);
+        const pageWriteMode = request.httpProps[N.PAGE_WRITE];
+        const isClear = pageWriteMode === 'clear';
 
-        const pageWriteMode = request.httpProps[N.PAGE_WRITE],
-            writeStream = fs.createWriteStream(request.uri, {
+        this._updatePageRanges(coll, pageRanges, startByte, endByte, request.id, isClear);
+
+        const writeStream = fs.createWriteStream(request.uri, {
                 flags: 'r+',
                 start: startByte,
                 defaultEncoding: 'utf8'
             });
 
         let pageContent;
-        if (pageWriteMode === 'update') {
+        if (isClear) {
+            // Zeroes will be written to the file to scrub the data
+            pageContent = new Array(endByte - startByte + 1).fill('\0').join('');
+        } else {
+            // Must be an update operation because it has already been verified in
+            // PageBlobHeaderSanity that the write mode is either 'clear' or 'update'.
+            // The request data will be written to the file
             pageContent = request.body;
         }
-        if (pageWriteMode === 'clear') {
-            pageContent = new Array(endbyte - startbyte + 1).fill('\0').join('');
-        }
+
         return new BbPromise((resolve, reject) => {
             writeStream
                 .on('error', (e) => {
@@ -676,29 +682,46 @@ class StorageManager {
         };
     }
 
-    _updatePageRanges(coll, pageRanges, startByte, endByte, id) {
+    _updatePageRanges(coll, pageRanges, startByte, endByte, id, isClear) {
         const startAlignment = startByte / 512,
             endAlignment = (endByte + 1) / 512;
         coll.remove(pageRanges);
-        coll.insert({
-            parentId: id,
-            start: startAlignment,
-            end: endAlignment
-        });
         const firstPage = pageRanges[0];
         const lastPage = pageRanges[pageRanges.length - 1];
-        if (firstPage && startAlignment > firstPage.start) {
+        if (isClear) {
+            // it's a clear operation
+            if (firstPage && startAlignment > firstPage.start) {
+                coll.insert({
+                    parentId: id,
+                    start: firstPage.start,
+                    end: startAlignment
+                })
+            }
+            if (lastPage && endAlignment < lastPage.end) {
+                coll.insert({
+                    parentId: id,
+                    start: endAlignment,
+                    end: lastPage.end
+                })
+            }
+        } else {
+            // it must be an update operation
+            let start, end
+            if (firstPage && startAlignment > firstPage.start) {
+                start = firstPage.start;
+            } else {
+                start = startAlignment;
+            }
+            if (lastPage && endAlignment < lastPage.end) {
+                end = lastPage.end;
+            } else {
+                end = endAlignment;
+            }
+
             coll.insert({
                 parentId: id,
-                start: firstPage.start,
-                end: endAlignment - 1
-            });
-        }
-        if (lastPage && endAlignment < lastPage.end) {
-            coll.insert({
-                parentId: id,
-                start: endAlignment + 1,
-                end: lastPage.end
+                start: start,
+                end: end
             });
         }
     }

--- a/lib/validation/blob/PageBlobHeaderSanity.js
+++ b/lib/validation/blob/PageBlobHeaderSanity.js
@@ -15,8 +15,12 @@ class PageBlobHeaderSanity {
             throw new AError(ErrorCodes.InvalidHeaderValue);
         }
 
-        const isClearSet = httpProps[N.PAGE_WRITE] === 'CLEAR';
-        if (isClearSet && httpProps[N.CONTENT_LENGTH] !== 0) {
+        if (!(httpProps[N.PAGE_WRITE] === 'clear' || httpProps[N.PAGE_WRITE] === 'update')) {
+            throw new AError(ErrorCodes.InvalidHeaderValue);
+        }
+
+        const isClearSet = httpProps[N.PAGE_WRITE] === 'clear';
+        if (isClearSet && httpProps[N.CONTENT_LENGTH] != 0) {
             throw new AError(ErrorCodes.InvalidHeaderValue);
         }
         if (isClearSet && httpProps[N.CONTENT_MD5]) {

--- a/lib/validation/blob/PageBlobHeaderSanity.js
+++ b/lib/validation/blob/PageBlobHeaderSanity.js
@@ -10,16 +10,19 @@ class PageBlobHeaderSanity {
 
     validate({ request = undefined }) {
         const httpProps = request.httpProps;
+        let pageWrite = httpProps[N.PAGE_WRITE];
 
-        if (!httpProps[N.PAGE_WRITE]) {
+        if (!pageWrite) {
             throw new AError(ErrorCodes.InvalidHeaderValue);
         }
 
-        if (!(httpProps[N.PAGE_WRITE] === 'clear' || httpProps[N.PAGE_WRITE] === 'update')) {
+        pageWrite = pageWrite.toLowerCase();
+
+        if (!(pageWrite === 'clear' || pageWrite === 'update')) {
             throw new AError(ErrorCodes.InvalidHeaderValue);
         }
 
-        const isClearSet = httpProps[N.PAGE_WRITE] === 'clear';
+        const isClearSet = pageWrite === 'clear';
         if (isClearSet && httpProps[N.CONTENT_LENGTH] != 0) {
             throw new AError(ErrorCodes.InvalidHeaderValue);
         }

--- a/lib/validation/blob/PutBlobHeaders.js
+++ b/lib/validation/blob/PutBlobHeaders.js
@@ -10,8 +10,15 @@ class PutBlobHeaders {
     }
 
     validate({ request = undefined }) {
-        if (request.entityType !== EntityType.PageBlob && request.httpProps[N.BLOB_CONTENT_LENGTH]) {
-            throw new AError(ErrorCodes.UnsupportedHeader);
+        const length = request.httpProps[N.BLOB_CONTENT_LENGTH];
+        if (request.entityType === EntityType.PageBlob) {
+            if (length && (length < 0 || length % 512 != 0)) {
+                throw new AError(ErrorCodes.InvalidHeaderValue);
+            }
+        } else {
+            if (length) {
+                throw new AError(ErrorCodes.UnsupportedHeader);
+            }
         }
     }
 }

--- a/test/blob.js
+++ b/test/blob.js
@@ -329,6 +329,80 @@ describe('Blob HTTP API', () => {
                     e.should.have.status(416);
                 });
         });
+        it('should write data to the page blob range [1024-1535]', () => {
+	    const bodydata = Buffer.alloc(512)
+            return chai.request(url)
+                .put(`${urlPath}/${containerName}/${pageBlobName}`)
+                .query({ comp: 'page' })
+                .set('x-ms-page-write', 'update')
+                .set('x-ms-range', 'bytes=1024-1535')
+                .set('Content-Type', 'application/octet-stream')
+                .send(bodydata)
+                .then((res) => {
+                    res.should.have.status(201);
+                });
+        });
+        it('should get the page ranges [0-511],[1024-1535] from the page blob', () => {
+            return chai.request(url)
+                .get(`${urlPath}/${containerName}/${pageBlobName}`)
+                .query({ comp: 'pagelist' })
+                .then((res) => {
+                    res.should.have.status(200);
+		    xml2js.Parser().parseString(res.text, function(err, result) {
+			expect(result.PageList.PageRange.length).to.equal(2);
+			expect(result.PageList.PageRange[0]).to.deep.equal({"Start":["0"],"End":["511"]});
+			expect(result.PageList.PageRange[1]).to.deep.equal({"Start":["1024"],"End":["1535"]});
+		    });
+                });
+        });
+	it('should write data to the page blob range [512-1023]', () => {
+	    const bodydata = Buffer.alloc(512)
+            return chai.request(url)
+                .put(`${urlPath}/${containerName}/${pageBlobName}`)
+                .query({ comp: 'page' })
+                .set('x-ms-page-write', 'update')
+                .set('x-ms-range', 'bytes=512-1023')
+                .set('Content-Type', 'application/octet-stream')
+                .send(bodydata)
+                .then((res) => {
+                    res.should.have.status(201);
+                });
+        });
+        it('should get the page range [0-1535] from the page blob', () => {
+            return chai.request(url)
+                .get(`${urlPath}/${containerName}/${pageBlobName}`)
+                .query({ comp: 'pagelist' })
+                .then((res) => {
+                    res.should.have.status(200);
+		    xml2js.Parser().parseString(res.text, function(err, result) {
+			expect(result.PageList.PageRange.length).to.equal(1);
+			expect(result.PageList.PageRange[0]).to.deep.equal({"Start":["0"],"End":["1535"]});
+		    });
+                });
+        });
+	it('should clear data in the page blob range [512-1023]', () => {
+            return chai.request(url)
+                .put(`${urlPath}/${containerName}/${pageBlobName}`)
+                .query({ comp: 'page' })
+                .set('x-ms-page-write', 'clear')
+                .set('x-ms-range', 'bytes=512-1023')
+                .then((res) => {
+                    res.should.have.status(201);
+                });
+        });
+        it('should get the page ranges [0-511],[1024-1535] from the page blob', () => {
+            return chai.request(url)
+                .get(`${urlPath}/${containerName}/${pageBlobName}`)
+                .query({ comp: 'pagelist' })
+                .then((res) => {
+                    res.should.have.status(200);
+		    xml2js.Parser().parseString(res.text, function(err, result) {
+			expect(result.PageList.PageRange.length).to.equal(2);
+			expect(result.PageList.PageRange[0]).to.deep.equal({"Start":["0"],"End":["511"]});
+			expect(result.PageList.PageRange[1]).to.deep.equal({"Start":["1024"],"End":["1535"]});
+		    });
+                });
+        });
     });
 
     describe('GET Blob', () => {


### PR DESCRIPTION
Hi, I was playing with the emulator with a client using the Azure Python SDK and ran into a few bugs in the page blob implementation. The two commits in this pull request contain fixes for these bugs and some page blob unit tests.

1. The code was in some places testing the value of the x-ms-page-write header against non-lower case values of 'update' and 'clear'.

2. Page ranges were not being properly updated. For example 
a) if the blob contains the ranges [0-511],[1024-1535]  and an update is done to the range [512-1023] then we should end up with a single range [0-1535] rather than three ranges [0-511],[512-1023],[1024-1535]. 
b) if the blob contains a single range [0-1535] and a clear is done to the range [512-1023] then we should end up with two ranges [0-511],[1024-1535].

