### PR TITLE
Use a directory structure to avoid filenames > 255 chars

### DIFF
--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -50,7 +50,7 @@ class Environment {
      * @memberof Environment
      */
     diskStorageUri(id) {
-        return path.join(this.localStoragePath, id);
+        return path.join(this.localStoragePath, id.match(/.{1,16}/g).join("/"));
     }
 
     // We prepend a specific character to guarantee unique ids.

--- a/lib/core/env.js
+++ b/lib/core/env.js
@@ -39,7 +39,8 @@ class Environment {
      * @memberof Environment
     * */
     webStorageUri(id) {
-        return `http://localhost:${this.blobStoragePort}/blobs/${id}`;
+        var splitId = id.match(/.{1,16}/g).join("/");
+        return `http://localhost:${this.blobStoragePort}/blobs/${splitId}`;
     }
 
     /**


### PR DESCRIPTION
# Description

Uploading a file with a very long file name causes the internal ID used for storage to exceed 255 characters which is not supported on a lot of file systems.

I checked the commit history and saw that using a flat structure was a deliberate decision. The patch fixes the blob store by introducing a directory hierarchy.

It works for what I tried to achieve, I'm not sure about other cases. Also, I'm not a JS developer, so pls be forgiving...

# Testcase

Create a resources with a very long filename.

```
curl -H "x-ms-blob-type: BlockBlob" --upload-file file.txt http://127.0.0.1:10000/devstoreaccount1/mycontainer/this-is-a-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-filenname
```

# Expected Result

The blob is created on the local disk.

# Actual Result

``` 
**PANIC** Something unexpected happened! Blob Storage Emulator may be in an inconsistent state!                                                                                               
{ Error: ENAMETOOLONG: name too long, open '<very long base 64 encoded string>'
    at Error (native)
  errno: -36,
  code: 'ENAMETOOLONG',
  syscall: 'open',
  path: '<very long base 64 encoded string>' }
```

