### PR TITLE
Fixes for CORS implementation

### DIFF
--- a/lib/actions/blob/PreflightBlobRequest.js
+++ b/lib/actions/blob/PreflightBlobRequest.js
@@ -12,9 +12,10 @@ class PreflightBlobRequest {
         const response = new AzuriteResponse(); // Add Access-Control-Expose-Headers
         response.addHttpProperty(N.ACCESS_CONTROL_ALLOW_ORIGIN, req.httpProps[N.ORIGIN]); // Refactor into response
         response.addHttpProperty(N.ACCESS_CONTROL_ALLOW_METHODS, req.httpProps[N.ACCESS_CONTROL_REQUEST_METHOD]);
-        response.addHttpProperty(N.ACCESS_CONTROL_ALLOW_HEADERS, req.httpProps[N.ACCESS_CONTROL_ALLOW_HEADERS]);
+        response.addHttpProperty(N.ACCESS_CONTROL_ALLOW_HEADERS, req.httpProps[N.ACCESS_CONTROL_REQUEST_HEADERS]);
         response.addHttpProperty(N.ACCESS_CONTROL_MAX_AGE, req.cors.maxAgeInSeconds);
         response.addHttpProperty(N.ACCESS_CONTROL_ALLOW_CREDENTIALS, true); // Refactor into response
+        res.set(response.httpProps);
         res.status(200).send();
     }
 }

--- a/lib/model/blob/AzuriteResponse.js
+++ b/lib/model/blob/AzuriteResponse.js
@@ -5,7 +5,7 @@ const uuidV1 = require('uuid/v1'),
     EntityType = require('./../../core/Constants').StorageEntityType;
 
 class AzuriteResponse {
-    constructor({ proxy = undefined, payload = undefined, query = {}, cors = undefined }) {
+    constructor({ proxy = undefined, payload = undefined, query = {}, cors = undefined } = {}) {
         this.httpProps = {};
         this.proxy = proxy;
         if (this.proxy) {

--- a/lib/model/blob/AzuriteResponse.js
+++ b/lib/model/blob/AzuriteResponse.js
@@ -34,6 +34,7 @@ class AzuriteResponse {
             this.httpProps[N.ACCESS_CONTROL_ALLOW_ORIGIN] = cors.origin;
             this.httpProps[N.ACCESS_CONTROL_EXPOSE_HEADERS] = cors.exposedHeaders;
             this.httpProps[N.ACCESS_CONTROL_ALLOW_CREDENTIALS] = true;
+            this.httpProps[N.ACCESS_CONTROL_ALLOW_HEADERS] = cors.exposedHeaders;
         }
     }
 


### PR DESCRIPTION
This fixes two issues with the CORS implementation in azurite.

Without this, CORS doesn't work when testing on azurite even though it works when testing on the live blobstore. I'm using azurite master on OSX with node `v8.4.0` .

The first issue can be reproduced by using the script below which will result in a failed destructuring assignment `“TypeError: Cannot match against 'undefined' or 'null’.”`
```#!/bin/bash

# Create the container
#az storage container create \
#    --name 'userblobs' \
#    --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'


CORS_XML="
<?xml version="1.0" encoding="utf-8"?>  
<StorageServiceProperties> 
    <Cors>  
        <CorsRule>  
            <AllowedOrigins>*</AllowedOrigins>  
            <AllowedMethods>PUT,POST,GET,HEAD,OPTIONS</AllowedMethods>  
            <MaxAgeInSeconds>200</MaxAgeInSeconds>  
            <ExposedHeaders>*</ExposedHeaders>  
            <AllowedHeaders>*</AllowedHeaders>  
        </CorsRule>  
    </Cors> 
</StorageServiceProperties> 
"

curl -X PUT \
    -H 'Accept: application/xml' \
    -H 'Content-Type: application/xml' \
    -d "$CORS_XML" \
    http://127.0.0.1:10000/devstoreaccount1?restype=service\&comp=properties


curl -H "Origin: http://localhost:8080" \
     -H "Access-Control-Request-Method: PUT" \
     -H "Access-Control-Request-Headers: x-ms-blob-content-disposition,x-ms-blob-type" \
     -X OPTIONS --verbose \
     http://127.0.0.1:10000/devstoreaccount1/userblobs/rasters/387dcec91bd8493ba9b8cd4cc3bb521d/example_1.tif\?se\=2018-03-17T16%3A22%3A51Z\&sp\=w\&sv\=2017-07-29\&sr\=b\&sig\=YhIBWOVv/G4XfWnowBVG9U2oLUeIbIcBqm9c7b0wzew%3D
```


The second issue can only be reproduced when testing CORS from a browser and is due to the fact that azurite wouldn't set the `Access-Control-Allow-Headers` on its response to the preflight request, making the browser believe CORS is disallowed.