### PR TITLE
Support uppercase x-ms-lease-action

### DIFF
--- a/lib/model/blob/AzuriteRequest.js
+++ b/lib/model/blob/AzuriteRequest.js
@@ -93,7 +93,7 @@ class AzuriteRequest {
         this.httpProps[N.RANGE_GET_CONTENT_MD5] = httpHeaders['x-ms-range-get-content-md5'];
         this.httpProps[N.DELETE_SNAPSHOTS] = httpHeaders['x-ms-delete-snapshots'];
         this.httpProps[N.LEASE_ID] = httpHeaders['x-ms-lease-id'];
-        this.httpProps[N.LEASE_ACTION] = httpHeaders['x-ms-lease-action'];
+        this.httpProps[N.LEASE_ACTION] = httpHeaders['x-ms-lease-action'] ? httpHeaders['x-ms-lease-action'].toLowerCase() : undefined;
         this.httpProps[N.LEASE_DURATION] = httpHeaders['x-ms-lease-duration'];
         this.httpProps[N.LEASE_BREAK_PERIOD] = httpHeaders['x-ms-lease-break-period'];
         this.httpProps[N.PROPOSED_LEASE_ID] = httpHeaders['x-ms-proposed-lease-id'];


### PR DESCRIPTION
Java sends the `x-ms-lease-action` value in the uppercase, so it have to be transformed into lowercase.