### PR TITLE
Don’t copy streams if the blob is the same.

### DIFF
--- a/lib/core/blob/StorageManager.js
+++ b/lib/core/blob/StorageManager.js
@@ -592,10 +592,29 @@ class StorageManager {
         let from = null,
             to = null;
 
-        from = fs.createReadStream(sourceProxy.original.uri);
-        // TODO: if blob type is block also copy committed blocks
-        to = fs.createWriteStream(env.diskStorageUri(request.id));
-        from.pipe(to);
+        const sourceUri = sourceProxy.original.uri,
+              targetUri = env.diskStorageUri(request.id);
+
+        if (sourceUri == targetUri) {
+            // when copying the blob on itself we don't need to pipe streams,
+            // but simply invoke the "finish" callback
+            from = {
+              on: (name, callback) => {
+              }
+            }
+            to = {
+              on: (name, callback) => {
+                if (name == 'finish') {
+                  callback();
+                }
+              }
+            };
+        } else {
+            from = fs.createReadStream(sourceProxy.original.uri);
+            // TODO: if blob type is block also copy committed blocks
+            to = fs.createWriteStream(env.diskStorageUri(request.id));
+            from.pipe(to);
+        }
 
         const coll = this.db.getCollection(request.containerName),
             blobProxyDestination = this._createOrUpdateBlob(coll, request),


### PR DESCRIPTION
There's an idiom to update the blob lastModified property:

```java
CloudBlockBlob blob = container.getBlockBlobReference(blobName);
blob.startCopy(blob);
```

We can optimize Azurite to recognize this idiom by comparing the source and the target in the `copyBlob()`. If they are the same, we don't need to pipe the contents, but we can invoke the "finished" callback immediately.